### PR TITLE
Drop snooper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kanopy-platform/go-http-middleware
 
-go 1.17
+go 1.18
 
 require (
 	github.com/felixge/httpsnoop v1.0.2

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/kanopy-platform/go-http-middleware
 go 1.18
 
 require (
-	github.com/felixge/httpsnoop v1.0.2
 	github.com/prometheus/client_golang v1.12.2
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,6 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW4o=
-github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/logging/logrus.go
+++ b/logging/logrus.go
@@ -1,10 +1,12 @@
 package logging
 
 import (
+	"maps"
 	"net/http"
+	"net/http/httptest"
 	"strings"
+	"time"
 
-	"github.com/felixge/httpsnoop"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -34,9 +36,8 @@ func NewLogrus(opts ...LogrusOptionFunc) *LogrusMiddleware {
 
 func (m *LogrusMiddleware) Middleware(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
-
-		// Execute the chain of handlers, while capturing HTTP metrics: code, bytes-written, duration
-		metrics := httpsnoop.CaptureMetrics(next, w, r)
+		start := time.Now()
+		recorder := httptest.NewRecorder()
 
 		host := r.Header.Get("x-forwarded-for")
 		if host == "" {
@@ -49,16 +50,24 @@ func (m *LogrusMiddleware) Middleware(next http.Handler) http.Handler {
 			}
 		}
 
+		next.ServeHTTP(recorder, r)
+
+		maps.Copy(w.Header(), recorder.Header())
+		w.WriteHeader(recorder.Code)
+		w.Write(recorder.Body.Bytes())
+
+		duration := time.Since(start)
+
 		m.log.WithFields(log.Fields{
 			"host":       host,
 			"method":     r.Method,
 			"path":       r.URL.Path,
 			"proto":      r.Proto,
-			"status":     metrics.Code,
-			"bytes":      metrics.Written,
+			"status":     recorder.Code,
+			"bytes":      recorder.Body.Len(),
 			"referer":    r.Header.Get("referer"),
 			"user_agent": r.Header.Get("user-agent"),
-			"time_ms":    metrics.Duration.Milliseconds(),
+			"time_ms":    duration.Milliseconds(),
 		}).Info("handled")
 	}
 	return http.HandlerFunc(fn)

--- a/logging/logrus_test.go
+++ b/logging/logrus_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func FakeHandler(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(http.StatusCreated)
 	w.Header().Set("Content-Type", "application/json")
 	fmt.Fprint(w, `{"retval": "done"}`)
 }
@@ -35,7 +35,12 @@ func TestLoggingMiddleware(t *testing.T) {
 	// assert middleware
 	m := NewLogrus(WithLogrus(logger))
 	m.Middleware(handler).ServeHTTP(rr, req)
+
+	expectedAttrs := []string{fmt.Sprintf("bytes=%d", rr.Body.Len()), "method=GET", "path=/some-path", "proto=HTTP/1.1"}
+
 	assert.NoError(t, writer.Flush())
-	assert.Contains(t, capture.String(), "method=GET path=/some-path proto=HTTP")
-	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, http.StatusCreated, rr.Code)
+	for _, attr := range expectedAttrs {
+		assert.Contains(t, capture.String(), attr)
+	}
 }


### PR DESCRIPTION
I'm proposing to drop the httpsnoop pkg and use the httptest.Recorder instead. We should rather use a library from the standard library than using third party ones when we can.
Reasons to use std over 3rd party:

1. Stability and Reliability
- The standard library is maintained by the core Go team and is rigorously tested.
- APIs rarely change, so your code is less likely to break during upgrades.

2. Security
- The Go team actively addresses security vulnerabilities in the standard library.
- You have fewer dependencies to track for vulnerabilities compared to third-party packages.

3. No Extra Dependencies
- Fewer external dependencies mean simpler builds, smaller binaries, and fewer potential points of failure.

**When to consider a third-party library?**
- If the standard library lacks required features.
- If there is a compelling need (e.g., significant productivity gains, better API, or required integrations).